### PR TITLE
Add KCOV support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: bash
 
-sudo: false
+sudo: true
+
+services:
+  - docker
 
 before_script:
   - chmod +x test/unittest.sh
@@ -14,5 +17,6 @@ before_script:
 script:
   - export PATH=$PATH:$PWD/bin/
   - pushd test/
-  - bash unittest.sh
+  - ./unittest.sh
   - popd
+  - docker build -t kcov . --build-arg TRAVIS_JOB_ID=$TRAVIS_JOB_ID

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,9 @@ script:
   - docker run --name kcov_container kcov_img ls
   - mkdir cov/
   - docker cp kcov_container2:/tmp/cov cov/
-  - cd cov && bash <(curl -s https://codecov.io/bash)
+  - cd cov
+  - ls -l
+  - pwd
+  - ls -l cov
+  - bash <(curl -s https://codecov.io/bash)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,9 @@ script:
   - pushd test/
   - ./unittest.sh
   - popd
-  - docker build -t kcov . --build-arg TRAVIS_JOB_ID=$TRAVIS_JOB_ID
+  - docker build -t kcov_img . --build-arg TRAVIS_JOB_ID=$TRAVIS_JOB_ID
+  - docker run --name kcov_container kcov_img ls
+  - mkdir cov/
+  - docker cp kcov_container2:/tmp/cov cov/
+  - cd cov && bash <(curl -s https://codecov.io/bash)
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
   - docker build -t kcov_img . --build-arg TRAVIS_JOB_ID=$TRAVIS_JOB_ID
   - docker run --name kcov_container kcov_img ls
   - mkdir cov/
-  - docker cp kcov_container2:/tmp/cov cov/
+  - docker cp kcov_container:/tmp/cov cov/
   - cd cov
   - ls -l
   - pwd

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,6 @@ ENV PS4=+
 ARG TRAVIS_JOB_ID
 ENV TRAVIS_JOB_ID=${TRAVIS_JOB_ID}
 
+RUN ln -s /bin/bash /bin/sh
 RUN cd /tmp/timelog/test && kcov --coveralls-id=${TRAVIS_JOB_ID} --include-path=/tmp/timelog/bin/timelog /tmp/cov/ unittest.sh
 RUN  bash <(curl -s https://codecov.io/bash) -s /tmp/cov

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ ARG TRAVIS_JOB_ID
 ENV TRAVIS_JOB_ID=${TRAVIS_JOB_ID}
 
 RUN cd /tmp/timelog/test && kcov --coveralls-id=${TRAVIS_JOB_ID} --include-path=/tmp/timelog/bin/timelog /tmp/cov/ unittest.sh
-RUN /bin/bash -c <(curl -s https://codecov.io/bash) -s /tmp/cov
+RUN /bin/bash -c "<(curl -s https://codecov.io/bash) -s /tmp/cov"

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,5 @@ ENV PS4=+
 ARG TRAVIS_JOB_ID
 ENV TRAVIS_JOB_ID=${TRAVIS_JOB_ID}
 
-RUN ln -sf /bin/bash /bin/sh
 RUN cd /tmp/timelog/test && kcov --coveralls-id=${TRAVIS_JOB_ID} --include-path=/tmp/timelog/bin/timelog /tmp/cov/ unittest.sh
-RUN  bash <(curl -s https://codecov.io/bash) -s /tmp/cov
+RUN /bin/bash -c <(curl -s https://codecov.io/bash) -s /tmp/cov

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,4 @@ ENV PS4=+
 ARG TRAVIS_JOB_ID
 ENV TRAVIS_JOB_ID=${TRAVIS_JOB_ID}
 
-RUN cd /tmp/timelog/test && kcov --coveralls-id=${TRAVIS_JOB_ID} --include-path=/tmp/timelog/bin/timelog /tmp/cov/ unittest.sh
-RUN /bin/bash -c "<(curl -s https://codecov.io/bash) -s /tmp/cov"
+RUN cd /tmp/timelog/test && kcov --include-path=/tmp/timelog/bin/timelog /tmp/cov/ unittest.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ ARG TRAVIS_JOB_ID
 ENV TRAVIS_JOB_ID=${TRAVIS_JOB_ID}
 
 RUN cd /tmp/timelog/test && kcov --coveralls-id=${TRAVIS_JOB_ID} --include-path=/tmp/timelog/bin/timelog /tmp/cov/ unittest.sh
-
+RUN  bash <(curl -s https://codecov.io/bash) -s /tmp/cov

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:12.04
+USER root
+RUN apt-get update
+
+RUN  apt-get update -qq
+
+# Precise
+RUN apt-get install -y elfutils libdw1/precise libasm1/precise libdw-dev/precise libelf-dev libcurl4-openssl-dev git curl cmake make build-essential
+
+# Xenial
+# RUN apt-get install -y pkg-config
+# RUN apt-get install -y binutils-dev libcurl4-openssl-dev zlib1g-dev libdw-dev libiberty-dev cmake git python curl
+
+RUN cd /tmp
+RUN git clone https://github.com/SimonKagstrom/kcov
+RUN printenv
+RUN cd kcov && mkdir build && cd build && cmake .. && make && make install && cd ..
+
+RUN mkdir /tmp/timelog
+RUN mkdir /tmp/timelog/test
+RUN mkdir /tmp/timelog/bin
+
+ADD test/unittest.sh /tmp/timelog/test/unittest.sh
+ADD test/test_dep.sh /tmp/timelog/test/test_dep.sh
+ADD bin/timelog /tmp/timelog/bin/timelog
+RUN cd /tmp/timelog/test && ./test_dep.sh && cd ..
+
+RUN chmod +x /tmp/timelog/test/unittest.sh
+RUN chmod +x /tmp/timelog/bin/timelog
+
+ENV PATH="$PATH:/tmp/timelog/bin"
+RUN mkdir /tmp/cov
+ENV PS4=+
+
+# Travis stuff
+ARG TRAVIS_JOB_ID
+ENV TRAVIS_JOB_ID=${TRAVIS_JOB_ID}
+
+RUN cd /tmp/timelog/test && kcov --coveralls-id=${TRAVIS_JOB_ID} --include-path=/tmp/timelog/bin/timelog /tmp/cov/ unittest.sh
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,6 @@ ENV PS4=+
 ARG TRAVIS_JOB_ID
 ENV TRAVIS_JOB_ID=${TRAVIS_JOB_ID}
 
-RUN ln -s /bin/bash /bin/sh
+RUN ln -sf /bin/bash /bin/sh
 RUN cd /tmp/timelog/test && kcov --coveralls-id=${TRAVIS_JOB_ID} --include-path=/tmp/timelog/bin/timelog /tmp/cov/ unittest.sh
 RUN  bash <(curl -s https://codecov.io/bash) -s /tmp/cov


### PR DESCRIPTION
Travis now builds a container that is running ubuntu 12 with kcov.
With failing attempts to get a 16.04 container running with kcov. This
commit results in picking ubuntu 12.04 as a version that works with kcov.

This closes #34